### PR TITLE
Add Xcode project generation

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -2,7 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
 	<key>LSUIElement</key>
-	<true/>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+project:
+	mint run xcodegen --spec xcodegen.yml
+
 test:
 	xcodebuild -project "Work Hours.xcodeproj" -clonedSourcePackagesDirPath SourcePackages -scheme "Work Hours" -configuration Debug -resultBundlePath test.xcresult -destination platform=macOS test 
 

--- a/Mintfile
+++ b/Mintfile
@@ -1,4 +1,3 @@
 nicklockwood/SwiftFormat@0.49.13
 realm/SwiftLint@0.47.1
-ChargePoint/xcparse@2.2.1
-tuist/xcbeautify@0.13.0
+yonaskolb/XcodeGen@2.35.0

--- a/xcodegen.yml
+++ b/xcodegen.yml
@@ -1,0 +1,34 @@
+name: Work Hours
+options:
+  bundleIdPrefix: com.teamniteo
+packages:
+  AppUpdater:
+    url: https://github.com/teamniteo/AppUpdater
+    branch: master
+  Defaults:
+    url: https://github.com/sindresorhus/Defaults
+    from: 7.2.0
+  LaunchAtLogin:
+    url: https://github.com/sindresorhus/LaunchAtLogin
+    from: 5.0.0
+  SwiftCSV:
+    url: https://github.com/swiftcsv/SwiftCSV
+    exactVersion: 0.7.1
+targets:
+  Work Hours:
+    type: application
+    platform: macOS
+    deploymentTarget: "11.0"
+    sources:
+      - Work Hours
+    info:
+      path: Info.plist
+      properties:
+        LSUIElement: true
+    settings:
+      CODE_SIGN_ENTITLEMENTS: Work Hours/WorkHours.entitlements
+    dependencies:
+      - package: AppUpdater
+      - package: Defaults
+      - package: LaunchAtLogin
+      - package: SwiftCSV


### PR DESCRIPTION
To allow contributors to more easily make additions, add Xcode project generation via XcodeGen to keep it simple. This allows me to build + run the app locally to make contributions.